### PR TITLE
Deploy to gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ deploy:
   github-token: $GITHUB_TOKEN
   keep-history: true
   verbose: true
+  on:
+    branch: deploy-pages
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,24 @@ sudo: false
 
 install:
   - npm install -g mustache
-  - travis_retry git clone --depth 1 https://github.com/mozilla/gecko-dev.git
-  - dev/build-data ./gecko-dev | tee data.json
+  - travis_retry git clone --depth 1 https://github.com/mozilla/gecko-dev.git ~/gecko-dev
+  - dev/build-data ~/gecko-dev > data.json
+  - cat data.json
 
 script:
-  - mustache data.json index.mustache | tee index.html
+  - mustache data.json index.mustache > index.html
+  - cat index.html
+
+before_deploy:
+  - git clean -df
 
 deploy:
-  provider: script
-  script: git status
-  on:
-    branch: travis-ci
+  provider: pages
+  skip-cleanup: true
+  github-token: $GITHUB_TOKEN
+  keep-history: true
+  verbose: true
+
+env:
+  global:
+    secure: KZOqiFI+9z5L/r086wprj7bZh9CEb0D4F00tiwAFZYBS9mq4HnnL2zI4yRlLpbmlCxvu77O2+4+wPgRJStBjDcChJxQBJG664+fY1fyDO/VS4V2GWEsCOALHi5dlc/3A/vrNNmysmEBmzWFu+DDrCC+21SbfjnwMwuUrCkowdebxAs6tovmN55/48yYf3AMJADcARX9HvtC5/Tg3+q07XFXn+J+D8X0BuUcz8uJfkE7VTKC84VNz9g94WGW6F94/RnoCGUj05Nt6FZDhKaFwBDeBZjX4TsR87FscBdryt2pdOMY3NaBF2R/BVZiHs2CKT2ZR32/jZQ37cm2aIRJuBdIJ4vtE0dToKe9ozUtoWQVarNqZee8NbAF7yTot83OayOT8PCpczU+7FvnqO0BD9XdXtqxFWC5eO6q2GrjgLoR5i6NpLOndW3O1HBTVT/ae6rz23OC/E6m6h1SRmX7N8V6GDr947wI36QCn76hDaUT3pgJlDtTLjrpJkUMAuKndog/6XfL5fWhHGVpr5w+SoinPJGgKmvGpxNtbaexgq3HQD+vGSgb0cdcbpI7SX1sGZnF9Uc41fcA/0EsskQ9gYXLX0mI5B8i1BtFXoOELNasL0hl+Hvg87v3eK3GCQVJZhNDSJyxBpKFi+BaAzWKVOD670zo4uV7AcKE6LGQeFvc=

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ deploy:
   keep-history: true
   verbose: true
   on:
-    branch: deploy-pages
+    branch: master
 
 env:
   global:

--- a/dev/build-data
+++ b/dev/build-data
@@ -37,16 +37,22 @@ echo_data_line()
   echo "{\"name\":\"$1\", \"loc\":$2}$3"
 }
 
-echo_date()
+echo_meta_date()
 {
-  echo "\"date\": \"$1\"$2"
+  echo "\"meta_date\": \"$1\"$2"
+}
+
+echo_title_date()
+{
+  echo "\"title_date\": \"$1\"$2"
 }
 
 cd $GECKO_DEV
 
 echo_header
 
-echo_date "$(date +'%b %Y')" ','
+echo_meta_date "$(date -u --iso-8601=seconds)" ','
+echo_title_date "$(date +'%b %Y')" ','
 
 echo_data_header
 

--- a/index.mustache
+++ b/index.mustache
@@ -1,5 +1,6 @@
 <html>
   <head>
+    <meta name="date" content="{{meta_date}}" />
     <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
     <script type="text/javascript">
       google.charts.load('current', {'packages':['corechart']});
@@ -28,7 +29,7 @@
     <a href="https://github.com/4e6/firefox-lang-stats"><img style="position: absolute; top: 0; left: 0; border: 0; z-index:100;" src="https://s3.amazonaws.com/github/ribbons/forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
     <div style="margin-left: 150px">
       <h2>How much Rust in Firefox?</h2>
-      <p><a href="https://github.com/mozilla/gecko-dev">mozilla/gecko-dev</a> repository statistics on {{date}}</p>
+      <p><a href="https://github.com/mozilla/gecko-dev">mozilla/gecko-dev</a> repository statistics on {{title_date}}</p>
     </div>
     <div id="piechart" style="width: 900px; height: 500px;"></div>
   </body>


### PR DESCRIPTION
Deploy to `gh-pages` branch after successful Travis build.

This allows automatic updating of the language statistics chart using a monthly Travis Cron build