### PR TITLE
Update checkout action and disable progress report

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: GitHub Pages
+name: Build Stats
 
 on:
   push:
@@ -13,12 +13,13 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           repository: mozilla/gecko-dev
           path: gecko-dev
+          show-progress: false
 
       - run: npm install -g mustache
 


### PR DESCRIPTION
This removes linter complains about outdated action. Disabling progress may speed up things a little.