### PR TITLE
Switch to new mozilla-firefox/firefox repository

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,15 +17,15 @@ jobs:
 
       - uses: actions/checkout@v2
         with:
-          repository: mozilla/gecko-dev
-          path: gecko-dev
+          repository: mozilla-firefox/firefox
+          path: firefox
 
       - run: npm install -g mustache
 
       - name: Build
         run: |
           mkdir build
-          dev/build-data ./gecko-dev > build/data.json
+          dev/build-data ./firefox > build/data.json
           cat build/data.json
           mustache build/data.json index.mustache > build/index.html
           cat build/index.html

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 How much Rust in Firefox? You can see the chart [here][gh-pages].
 
 Repository contains scripts collecting the language statistics for
-[mozilla/gecko-dev] repository. Gathered data then assembled into a pie chart
-`index.mustache`.
+[mozilla-firefox/firefox] repository. Gathered data then assembled into a pie
+chart `index.mustache`.
 
 Page is updated weekly with a Travis Cron job. See the `date` meta tag for
 the exact build time.
@@ -14,7 +14,7 @@ the exact build time.
 Build json document with the language details:
 
 ```
-dev/build-data ~/gecko-dev > data.json
+dev/build-data ~/firefox > data.json
 ```
 
 Expand mustache template:
@@ -24,5 +24,5 @@ mustache data.json index.mustache > index.html
 ```
 
 
-[mozilla/gecko-dev]: https://github.com/mozilla/gecko-dev
+[mozilla-firefox/firefox]: https://github.com/mozilla-firefox/firefox
 [gh-pages]: https://4e6.github.io/firefox-lang-stats/

--- a/index.mustache
+++ b/index.mustache
@@ -36,7 +36,7 @@
     <a href="https://github.com/4e6/firefox-lang-stats"><img style="position: absolute; top: 0; left: 0; border: 0; z-index:100;" src="https://s3.amazonaws.com/github/ribbons/forkme_left_darkblue_121621.png" alt="Fork me on GitHub"></a>
     <div style="margin-left: 150px">
       <h2>How much Rust in Firefox?</h2>
-      <p><a href="https://github.com/mozilla/gecko-dev">mozilla/gecko-dev</a> repository statistics on {{title_date}}</p>
+      <p><a href="https://github.com/mozilla-firefox/firefox">mozilla-firefox/firefox</a> repository statistics on {{title_date}}</p>
     </div>
     <div id="piechart" style="width: 900px; height: 500px;"></div>
   </body>


### PR DESCRIPTION
Firefox now lives in mozilla-firefox/firefox, gecko-dev is deprecated and archived.

Announcement E-Mail: https://groups.google.com/a/mozilla.org/g/firefox-dev/c/l61EZcU4i64/m/mgGSyBbEBgAJ